### PR TITLE
updating repo path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Babel Plugin to enable relative imports",
   "main": "lib/index.js",
-  "repository": "mgcrea/babel-plugin-local-import",
+  "repository": "mgcrea/babel-plugin-relative-import",
   "author": "Olivier Louvignes <olivier@mg-crea.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Currently `npm home babel-plugin-relative-import` shows a github 404. I think this change will fix the issue.  I didn't update the version number to `1.0.2` because some people don't like PR's like that, so I'll let you do that :)
